### PR TITLE
캘린더 월별 일정 조회 기능 및 메인 페이지 UI 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@mui/styled-engine": "npm:@mui/styled-engine-sc@latest",
     "@mui/x-date-pickers": "^5.0.0-beta.5",
     "@reduxjs/toolkit": "^1.8.4",
+    "@tanstack/react-query": "^4.1.3",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",

--- a/src/assets/icons.js
+++ b/src/assets/icons.js
@@ -38,6 +38,20 @@ export const IconBack = () => (
   </svg>
 );
 
+// Widget
+export const IconDetail = () => (
+  <svg width="7" height="11" viewBox="0 0 7 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M4.88756 5.5L0.256282 1.3413C-0.0854271 1.03446 -0.0854271 0.536971 0.256282 0.23013C0.59799 -0.0767102 1.15201 -0.0767102 1.49372 0.23013L6.74372 4.94442C7.08543 5.25126 7.08543 5.74874 6.74372 6.05558L1.49372 10.7699C1.15201 11.0767 0.59799 11.0767 0.256282 10.7699C-0.0854271 10.463 -0.0854271 9.96554 0.256282 9.6587L4.88756 5.5Z" fill="#262626"/>
+  </svg>
+);
+
+export const IconAlert = () => (
+  <svg width="20" height="24" viewBox="0 0 20 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M16 7.95021C16 4.59508 13.3137 1.87521 10 1.87521C6.68629 1.87521 4 4.59508 4 7.95021C4 15.0377 1 17.0627 1 17.0627H19C19 17.0627 16 15.0377 16 7.95021" stroke="#7D7D7D" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+    <path d="M11.7298 21.1127C11.372 21.7372 10.7128 22.1216 9.99978 22.1216C9.28671 22.1216 8.62757 21.7372 8.26978 21.1127" stroke="#7D7D7D" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+  </svg>
+);
+
 // Calendar
 export const IconPlus = () => (
   <svg width="21" height="21" viewBox="0 0 21 21" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -34,7 +34,7 @@ const Calendar = () => {
           <IconBack />
         </button>
       </header>
-      <Month monthMatrix={curMonth} monthIdx={monthIdx} />
+      <Month monthMatrix={curMonth} />
     </CalendarContainer>
   );
 };
@@ -43,7 +43,7 @@ export default Calendar;
 
 const CalendarContainer = styled.article`
   position: fixed;
-  top: 0;
+  top: 127px;
   left: 0;
   right: 0;
   display: flex;

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -1,18 +1,38 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
+import dayjs from 'dayjs';
 import { getMonth } from '../../util';
 import { useDispatch, useSelector } from 'react-redux';
-import { setMonthIdx } from '../../redux/modules/calendarSlice';
+import {
+  setMonthIdx,
+  handlePrevMonth,
+  handleNextMonth,
+} from '../../redux/modules/calendarSlice';
 import Month from './Month';
+import { IconBack } from '../../assets/icons';
 
 const Calendar = () => {
   const dispatch = useDispatch();
   const { monthIdx } = useSelector((state) => state.calendar);
   const [curMonth, setCurMonth] = useState(getMonth());
 
+  useEffect(() => {
+    setCurMonth(getMonth(monthIdx));
+  }, [monthIdx]);
+
   return (
     <CalendarContainer>
-      <h2>{monthIdx + 1}월</h2>
+      <header>
+        <button onClick={() => dispatch(handlePrevMonth())}>
+          <IconBack />
+        </button>
+        <h2>
+          {dayjs(new Date(dayjs().year(), monthIdx)).format('YYYY년 M월')}
+        </h2>
+        <button onClick={() => dispatch(handleNextMonth())} className="next">
+          <IconBack />
+        </button>
+      </header>
       <Month monthMatrix={curMonth} monthIdx={monthIdx} />
     </CalendarContainer>
   );
@@ -31,9 +51,22 @@ const CalendarContainer = styled.article`
   padding: 15px 10px 30px 10px;
   background: #f3f3f3;
   text-align: center;
-  h2 {
-    margin: 1em 0;
-    font-size: 1.2em;
-    font-weight: 700;
+  header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    h2 {
+      margin: 1em 0;
+      font-size: 1.2em;
+      font-weight: 700;
+    }
+    button {
+      height: 30px;
+      padding: 5px 10px;
+      border-radius: 10px;
+      &.next svg {
+        transform: rotate(180deg);
+      }
+    }
   }
 `;

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -23,6 +23,7 @@ const Calendar = () => {
   return (
     <CalendarContainer>
       <header>
+        {/* FIXME: 버튼 아이콘 수정 */}
         <button onClick={() => dispatch(handlePrevMonth())}>
           <IconBack />
         </button>
@@ -49,15 +50,15 @@ const CalendarContainer = styled.article`
   flex-direction: column;
   height: 356px;
   padding: 15px 10px 30px 10px;
-  background: #f3f3f3;
+  background: #fafafa;
   text-align: center;
   header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    margin: 11px 0 27px;
     h2 {
-      margin: 1em 0;
-      font-size: 1.2em;
+      font-size: 1em;
       font-weight: 700;
     }
     button {

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -1,30 +1,19 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import dayjs from 'dayjs';
-// import { useQueryClient } from '@tanstack/react-query';
 import { getMonth } from '../../util';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  setMonthIdx,
-  handlePrevMonth,
-  handleNextMonth,
-} from '../../redux/modules/calendarSlice';
+import { setMonthIdx } from '../../redux/modules/calendarSlice';
 import Month from './Month';
 import { IconBack } from '../../assets/icons';
 
 const Calendar = () => {
   const dispatch = useDispatch();
   const { selectedDate, monthIdx } = useSelector((state) => state.calendar);
-  // const [selectedDate, setSelectedDate] = useState(dayjs());
   const [curMonthMatrix, setCurMonthMatrix] = useState(getMonth());
 
   useEffect(() => {
     setCurMonthMatrix(getMonth(monthIdx));
-    // setSelectedDate(dayjs(new Date(dayjs().year(), monthIdx)));
-    // dispatch(setYearIdx(selectedDate.format('YYYY')));
   }, [monthIdx]);
-
-  // const queryClient = useQueryClient();
 
   return (
     <CalendarContainer>
@@ -32,7 +21,6 @@ const Calendar = () => {
         {/* FIXME: 버튼 아이콘 수정 */}
         <button
           onClick={() => {
-            // queryClient.invalidateQueries(['schedule']);
             dispatch(setMonthIdx(monthIdx - 1));
           }}
         >
@@ -41,9 +29,6 @@ const Calendar = () => {
         <h2>{selectedDate.format('YYYY년 M월')}</h2>
         <button
           onClick={() => {
-            // queryClient.invalidateQueries(['schedule'], {
-            //   refetchType: 'all',
-            // });
             dispatch(setMonthIdx(monthIdx + 1));
           }}
           className="next"

--- a/src/components/calendar/Calendar.jsx
+++ b/src/components/calendar/Calendar.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import dayjs from 'dayjs';
+// import { useQueryClient } from '@tanstack/react-query';
 import { getMonth } from '../../util';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -13,28 +14,44 @@ import { IconBack } from '../../assets/icons';
 
 const Calendar = () => {
   const dispatch = useDispatch();
-  const { monthIdx } = useSelector((state) => state.calendar);
-  const [curMonth, setCurMonth] = useState(getMonth());
+  const { selectedDate, monthIdx } = useSelector((state) => state.calendar);
+  // const [selectedDate, setSelectedDate] = useState(dayjs());
+  const [curMonthMatrix, setCurMonthMatrix] = useState(getMonth());
 
   useEffect(() => {
-    setCurMonth(getMonth(monthIdx));
+    setCurMonthMatrix(getMonth(monthIdx));
+    // setSelectedDate(dayjs(new Date(dayjs().year(), monthIdx)));
+    // dispatch(setYearIdx(selectedDate.format('YYYY')));
   }, [monthIdx]);
+
+  // const queryClient = useQueryClient();
 
   return (
     <CalendarContainer>
       <header>
         {/* FIXME: 버튼 아이콘 수정 */}
-        <button onClick={() => dispatch(handlePrevMonth())}>
+        <button
+          onClick={() => {
+            // queryClient.invalidateQueries(['schedule']);
+            dispatch(setMonthIdx(monthIdx - 1));
+          }}
+        >
           <IconBack />
         </button>
-        <h2>
-          {dayjs(new Date(dayjs().year(), monthIdx)).format('YYYY년 M월')}
-        </h2>
-        <button onClick={() => dispatch(handleNextMonth())} className="next">
+        <h2>{selectedDate.format('YYYY년 M월')}</h2>
+        <button
+          onClick={() => {
+            // queryClient.invalidateQueries(['schedule'], {
+            //   refetchType: 'all',
+            // });
+            dispatch(setMonthIdx(monthIdx + 1));
+          }}
+          className="next"
+        >
           <IconBack />
         </button>
       </header>
-      <Month monthMatrix={curMonth} />
+      <Month monthMatrix={curMonthMatrix} />
     </CalendarContainer>
   );
 };

--- a/src/components/calendar/Day.jsx
+++ b/src/components/calendar/Day.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import dayjs from 'dayjs';
 import cn from 'classnames';
 import styled from 'styled-components';
 import { useSelector } from 'react-redux';
@@ -9,7 +10,13 @@ const Day = ({ day, weekIdx }) => {
   return (
     <>
       <DayBox>
-        <h3 className={cn(`${monthIdx % 12 !== day.month() ? 'other' : 'this'}`)}>
+        <h3
+          className={cn(
+            'day',
+            monthIdx % 12 !== day.month() && 'other',
+            day.format('YY-MM-DD') === dayjs().format('YY-MM-DD') && 'today',
+          )}
+        >
           {day.format('D')}
         </h3>
       </DayBox>
@@ -23,7 +30,16 @@ const DayBox = styled.section`
   display: flex;
   flex-direction: column;
   align-items: center;
+  font-size: 15px;
   h3.other {
     color: #b4b4b4;
+  }
+  h3.today {
+    margin-top: -3px;
+    padding: 3px 4px;
+    border-radius: 50%;
+    background: #000;
+    color: #fff;
+    font-weight: 700;
   }
 `;

--- a/src/components/calendar/Day.jsx
+++ b/src/components/calendar/Day.jsx
@@ -9,7 +9,7 @@ const Day = ({ day, weekIdx }) => {
   return (
     <>
       <DayBox>
-        <h3 className={cn(`${monthIdx !== day.month() ? 'other' : 'this'}`)}>
+        <h3 className={cn(`${monthIdx % 12 !== day.month() ? 'other' : 'this'}`)}>
           {day.format('D')}
         </h3>
       </DayBox>

--- a/src/components/calendar/ScheduleList.jsx
+++ b/src/components/calendar/ScheduleList.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import styled from 'styled-components';
+
+const ScheduleList = ({ schedule }) => {
+  return (
+    <ScheduleItem>
+      <CategoryAndDate>
+        {/* TODO: category 영어로 받아서 theme 적용 */}
+        <div val={schedule.category} className="circle" />
+        {schedule.startDate === schedule.endDate ? (
+          <span className="date">
+            {dayjs(schedule.startDate).format('M월 DD일, dd')}
+          </span>
+        ) : (
+          <span className="date">
+            {dayjs(schedule.startDate).format('M월 DD일, dd')} ~{' '}
+            {dayjs(schedule.endDate).format('M월 DD일, dd')}
+          </span>
+        )}
+      </CategoryAndDate>
+      <strong>{schedule.title}</strong>
+    </ScheduleItem>
+  );
+};
+
+export default ScheduleList;
+
+const ScheduleItem = styled.li`
+  margin-bottom: 20px;
+`;
+
+const CategoryAndDate = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  div.circle {
+    width: 10px;
+    height: 10px;
+    margin-right: 7px;
+    border-radius: 50%;
+    background: #45bfff;
+  }
+  span.date {
+    color: #adadad;
+    font-size: 12px;
+    font-weight: 500;
+  }
+`;

--- a/src/components/calendar/Summary.jsx
+++ b/src/components/calendar/Summary.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Summary = () => {
+  return (
+    <CalendarSummary>
+      <Category val="eatout">
+        <div />
+        외식 +1
+      </Category>
+      <Category val="trip">
+        <div />
+        여행 +1
+      </Category>
+      <Category val="cook">
+        <div />
+        요리 +0
+      </Category>
+      <Category val="clean">
+        <div />
+        청소 +5
+      </Category>
+      <Category val="etc">
+        <div />
+        기타 +3
+      </Category>
+    </CalendarSummary>
+  );
+};
+
+export default Summary;
+
+const CalendarSummary = styled.section`
+  position: fixed;
+  top: 75px;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: center;
+  height: 52px;
+  gap: 5px 10px;
+  padding: 0 18px;
+`;
+
+const Category = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  color: #7d7d7d;
+  font-size: 14px;
+  letter-spacing: -0.9px;;
+  div {
+    width: 7px;
+    height: 7px;
+    margin-right: 4px;
+    border-radius: 50%;
+    background: ${({ theme, val }) => theme.palette[val]};
+  }
+`;

--- a/src/components/common/Loading.jsx
+++ b/src/components/common/Loading.jsx
@@ -6,8 +6,7 @@ const Loading = () => {
   return (
     <>
       <LoadingSpinner>
-        {/* FIXME: 추후 메인 색상으로 수정 */}
-        <PuffLoader color="#77b256" />
+        <PuffLoader color="#3ec192" />
       </LoadingSpinner>
     </>
   );

--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -67,7 +67,7 @@ const Navigation = styled.nav`
   left: 0;
   right: 0;
   bottom: 0;
-  border-top: 1px solid #acacac;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
   background: #fff;
   color: #868686;
   font-size: 12px;

--- a/src/components/common/Navbar.jsx
+++ b/src/components/common/Navbar.jsx
@@ -1,7 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-import { IconHome, IconGallery, IconVoice, IconCommunity, IconSettings } from '../../assets/icons';
+import {
+  IconHome,
+  IconGallery,
+  IconVoice,
+  IconCommunity,
+  IconSettings,
+} from '../../assets/icons';
 
 const Navbar = () => {
   const { pathname } = useLocation();
@@ -11,7 +17,7 @@ const Navbar = () => {
   useEffect(() => {
     paths.includes(pathname) ? setIsShowing(false) : setIsShowing(true);
   }, [pathname]);
-  
+
   return (
     <>
       {isShowing && (
@@ -19,7 +25,8 @@ const Navbar = () => {
           <Lists>
             <li>
               <Menu to="/">
-                <IconHome />홈
+                <IconHome />
+                캘린더
               </Menu>
             </li>
             <li>
@@ -89,10 +96,10 @@ const Menu = styled(NavLink)`
     margin-bottom: 2px;
   }
   &.active {
-    color: #2d2d2d;
+    color: ${({ theme }) => theme.palette.primary.main};
     font-weight: 600;
     svg path {
-      fill: #2d2d2d;
+      fill: ${({ theme }) => theme.palette.primary.main};
     }
   }
 `;

--- a/src/components/family/Widget.jsx
+++ b/src/components/family/Widget.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import styled from 'styled-components';
+import api from '../../api/AxiosManager';
+import { IconAlert, IconDetail } from '../../assets/icons';
+
+const Widget = () => {
+  // FIXME: 랭킹 api 완성 후 교체 - 방울 정보 및 화목 등급 필요
+  const getFamilyInfo = async () => {
+    try {
+      const res = await api.get('/family');
+      return res.data.data;
+    } catch (err) {
+      console.log(err.response.data);
+    }
+  };
+
+  const { data: familyInfo } = useQuery(['familyInfo'], getFamilyInfo, {
+    refetchOnWindowFocus: false,
+  });
+
+  console.log(familyInfo);
+
+  return (
+    <FamilyWidget>
+      <LeftWrapper>
+        <Circle>화목등급 이미지</Circle>
+        <div>
+          {/* TODO: 가족 정보 페이지 링크 추가 */}
+          <strong>{familyInfo.familyName}<IconDetail /></strong>
+          <p>
+            33방울 <span>| 140방울</span>
+            <span className="level">씨앗</span>
+          </p>
+        </div>
+      </LeftWrapper>
+      {/* TODO: 알림 페이지 링크 추가 */}
+      <IconAlert />
+    </FamilyWidget>
+  );
+};
+
+export default Widget;
+
+const FamilyWidget = styled.section`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 25px 20px 0;
+  strong {
+    display: block;
+    margin-bottom: 5px;
+    font-size: 20px;
+    svg {
+      margin: -2px 0 0 8px;
+    }
+  }
+`;
+
+const LeftWrapper = styled.div`
+  display: flex;
+  p {
+    font-size: 14px;
+    span {
+      color: #a5a5a5;
+      &.level {
+        margin-left: 5px;
+        border-radius: 60px;
+        padding: 1px 9px;
+        background: #d3d3d3;
+        color: #fff;
+        font-size: 14px;
+      }
+    }
+  }
+`;
+
+const Circle = styled.div`
+  width: 50px;
+  height: 50px;
+  margin-right: 11px;
+  border-radius: 50%;
+  background: #e4efd5;
+  font-size: 0.5em;
+`;

--- a/src/components/family/Widget.jsx
+++ b/src/components/family/Widget.jsx
@@ -19,8 +19,6 @@ const Widget = () => {
     refetchOnWindowFocus: false,
   });
 
-  console.log(familyInfo);
-
   return (
     <FamilyWidget>
       <LeftWrapper>

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 import Loading from './components/common/Loading';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Provider } from 'react-redux';
 import store from './redux/store';
 import AuthProvider from './context/AuthProvider';
@@ -10,19 +11,29 @@ import { ThemeProvider } from '@mui/material/styles';
 import { theme } from './styles/GlobalStyle';
 import App from './App';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      suspense: true,
+    },
+  },
+});
+
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <Suspense fallback={<Loading />}>
-    <Provider store={store}>
-      <AuthProvider>
-        <BrowserRouter>
-          <HelmetProvider>
-            <ThemeProvider theme={theme}>
-              <App />
-            </ThemeProvider>
-          </HelmetProvider>
-        </BrowserRouter>
-      </AuthProvider>
-    </Provider>
+    <QueryClientProvider client={queryClient}>
+      <Provider store={store}>
+        <AuthProvider>
+          <BrowserRouter>
+            <HelmetProvider>
+              <ThemeProvider theme={theme}>
+                <App />
+              </ThemeProvider>
+            </HelmetProvider>
+          </BrowserRouter>
+        </AuthProvider>
+      </Provider>
+    </QueryClientProvider>
   </Suspense>,
 );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,16 +3,14 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
+import api from '../api/AxiosManager';
 
 import PageTitle from '../components/common/PageTitle';
 import Widget from '../components/family/Widget';
 import Summary from '../components/calendar/Summary';
 import Calendar from '../components/calendar/Calendar';
 import ScheduleList from '../components/calendar/ScheduleList';
-import api from '../api/AxiosManager';
-
 import { IconPlus } from '../assets/icons';
-import LoremText from '../components/common/LoremText';
 
 const Home = () => {
   const { selectedDate, monthIdx } = useSelector((state) => state.calendar);
@@ -51,7 +49,7 @@ const Home = () => {
 
   return (
     <>
-      <PageTitle title="캘린더 홈" />
+      <PageTitle title="홈 - 캘린더" />
       <Widget />
       <Main>
         <h1 className="hidden">캘린더 홈</h1>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,15 +1,54 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
 
 import PageTitle from '../components/common/PageTitle';
 import Widget from '../components/family/Widget';
 import Summary from '../components/calendar/Summary';
 import Calendar from '../components/calendar/Calendar';
+import ScheduleList from '../components/calendar/ScheduleList';
+import api from '../api/AxiosManager';
+
 import { IconPlus } from '../assets/icons';
 import LoremText from '../components/common/LoremText';
 
 const Home = () => {
+  const { selectedDate, monthIdx } = useSelector((state) => state.calendar);
+
+  const getMonthSchedule = async () => {
+    try {
+      const res = await api.get(
+        `/schedules?year=${selectedDate.format(
+          'YYYY',
+        )}&month=${selectedDate.format('M')}`,
+      );
+      return res.data.data;
+    } catch (err) {
+      console.log(err.response.data);
+    }
+  };
+
+  const { data: monthSchedule, refetch } = useQuery(
+    ['schedule'],
+    getMonthSchedule,
+  );
+
+  useEffect(() => {
+    refetch();
+  }, [monthIdx]);
+
+  // FIXME: 개발 끝나면 지우기
+  useEffect(() => {
+    console.log(
+      `/schedules?year=${selectedDate.format(
+        'YYYY',
+      )}&month=${selectedDate.format('M')}`,
+    );
+    console.log(monthSchedule);
+  }, [monthSchedule]);
+
   return (
     <>
       <PageTitle title="캘린더 홈" />
@@ -26,7 +65,15 @@ const Home = () => {
         )}
         <Summary />
         <Calendar />
-        <LoremText />
+        {monthSchedule.schedules.length > 0 ? (
+          <ul>
+            {monthSchedule.schedules.map((schedule, i) => (
+              <ScheduleList key={i} schedule={schedule} />
+            ))}
+          </ul>
+        ) : (
+          <p>{selectedDate.format('YYYY년 M월')} 일정이 없습니다.</p>
+        )}
       </Main>
     </>
   );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -42,6 +42,7 @@ const BtnAdd = styled(Link)`
   bottom: 80px;
   right: 20px;
   padding: 15px;
-  background: #7d7d7d;
+  background: ${({ theme }) => theme.palette.primary.main};
   border-radius: 50%;
+  box-shadow: 0px 3px 30px rgba(0, 0, 0, 0.0784314);
 `;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+
 import PageTitle from '../components/common/PageTitle';
+import Widget from '../components/family/Widget';
+import Summary from '../components/calendar/Summary';
 import Calendar from '../components/calendar/Calendar';
 import { IconPlus } from '../assets/icons';
 import LoremText from '../components/common/LoremText';
@@ -10,6 +13,7 @@ const Home = () => {
   return (
     <>
       <PageTitle title="캘린더 홈" />
+      <Widget />
       <Main>
         <h1 className="hidden">캘린더 홈</h1>
         {/* TODO: 선택된 날짜 state로 관리하기 (기본값: 오늘) */}
@@ -20,6 +24,7 @@ const Home = () => {
             <IconPlus />
           </BtnAdd>
         )}
+        <Summary />
         <Calendar />
         <LoremText />
       </Main>
@@ -32,8 +37,8 @@ export default Home;
 const Main = styled.main`
   position: relative;
   overflow-y: auto;
-  height: calc(100vh - 356px - 65px);
-  margin-top: 356px;
+  height: calc(100vh - 110px - 356px - 65px);
+  margin-top: 465px;
   padding: 20px 20px 20px 20px;
 `;
 

--- a/src/pages/calendar/Schedule.jsx
+++ b/src/pages/calendar/Schedule.jsx
@@ -135,7 +135,7 @@ const Schedule = () => {
                 type="radio"
                 name="category"
                 id="cat-1"
-                value="외식"
+                value="EAT_OUT"
                 onChange={(e) => setCategory(e.target.value)}
                 hidden
               />
@@ -144,7 +144,7 @@ const Schedule = () => {
                 type="radio"
                 name="category"
                 id="cat-2"
-                value="여행"
+                value="TRIP"
                 onChange={(e) => setCategory(e.target.value)}
                 hidden
               />
@@ -153,7 +153,7 @@ const Schedule = () => {
                 type="radio"
                 name="category"
                 id="cat-3"
-                value="요리"
+                value="COOK"
                 onChange={(e) => setCategory(e.target.value)}
                 hidden
               />
@@ -162,7 +162,7 @@ const Schedule = () => {
                 type="radio"
                 name="category"
                 id="cat-4"
-                value="청소"
+                value="CLEAN"
                 onChange={(e) => setCategory(e.target.value)}
                 hidden
               />
@@ -171,7 +171,7 @@ const Schedule = () => {
                 type="radio"
                 name="category"
                 id="cat-5"
-                value="기타"
+                value="ETC"
                 onChange={(e) => setCategory(e.target.value)}
                 hidden
               />
@@ -180,7 +180,7 @@ const Schedule = () => {
                 type="radio"
                 name="category"
                 id="cat-6"
-                value="개인"
+                value="PERSONAL"
                 onChange={(e) => setCategory(e.target.value)}
                 hidden
               />

--- a/src/pages/calendar/Schedule.jsx
+++ b/src/pages/calendar/Schedule.jsx
@@ -63,7 +63,7 @@ const Schedule = () => {
 
   return (
     <>
-      <PageTitle title="캘린더 홈" />
+      <PageTitle title="캘린더 일정기록" />
       <Header text="일정기록" />
       <ScheduleSection>
         <ScheduleForm onSubmit={(e) => onSubmitSchedule(e)}>

--- a/src/pages/calendar/Schedule.jsx
+++ b/src/pages/calendar/Schedule.jsx
@@ -63,7 +63,7 @@ const Schedule = () => {
 
   return (
     <>
-      <PageTitle title="캘린더 일정기록" />
+      <PageTitle title="일정기록 - 캘린더" />
       <Header text="일정기록" />
       <ScheduleSection>
         <ScheduleForm onSubmit={(e) => onSubmitSchedule(e)}>

--- a/src/redux/modules/calendarSlice.js
+++ b/src/redux/modules/calendarSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 import dayjs from 'dayjs';
 
 const initialState = {
+  selectedDate: dayjs(),
   monthIdx: dayjs().month(),
 };
 
@@ -11,6 +12,10 @@ const calendarSlice = createSlice({
   reducers: {
     setMonthIdx: (state, action) => {
       state.monthIdx = action.payload;
+      state.selectedDate = dayjs(new Date(dayjs().year(), action.payload));
+    },
+    setDay: (state, action) => {
+      state.selectedDate = dayjs(new Date(dayjs().year(), state.monthIdx, action.payload));
     },
     handlePrevMonth: (state) => {
       state.monthIdx -= 1;
@@ -21,7 +26,7 @@ const calendarSlice = createSlice({
   },
 });
 
-export const { setMonthIdx, handlePrevMonth, handleNextMonth } =
+export const { setMonthIdx, setDay, handlePrevMonth, handleNextMonth } =
   calendarSlice.actions;
 
 export default calendarSlice.reducer;

--- a/src/redux/modules/calendarSlice.js
+++ b/src/redux/modules/calendarSlice.js
@@ -15,18 +15,13 @@ const calendarSlice = createSlice({
       state.selectedDate = dayjs(new Date(dayjs().year(), action.payload));
     },
     setDay: (state, action) => {
-      state.selectedDate = dayjs(new Date(dayjs().year(), state.monthIdx, action.payload));
-    },
-    handlePrevMonth: (state) => {
-      state.monthIdx -= 1;
-    },
-    handleNextMonth: (state) => {
-      state.monthIdx += 1;
+      state.selectedDate = dayjs(
+        new Date(dayjs().year(), state.monthIdx, action.payload),
+      );
     },
   },
 });
 
-export const { setMonthIdx, setDay, handlePrevMonth, handleNextMonth } =
-  calendarSlice.actions;
+export const { setMonthIdx, setDay } = calendarSlice.actions;
 
 export default calendarSlice.reducer;

--- a/src/redux/modules/calendarSlice.js
+++ b/src/redux/modules/calendarSlice.js
@@ -12,8 +12,16 @@ const calendarSlice = createSlice({
     setMonthIdx: (state, action) => {
       state.monthIdx = action.payload;
     },
+    handlePrevMonth: (state) => {
+      state.monthIdx -= 1;
+    },
+    handleNextMonth: (state) => {
+      state.monthIdx += 1;
+    },
   },
 });
 
-export const { setMonthIdx } = calendarSlice.actions;
+export const { setMonthIdx, handlePrevMonth, handleNextMonth } =
+  calendarSlice.actions;
+
 export default calendarSlice.reducer;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -5,6 +5,8 @@ export const store = configureStore({
   reducer: {
     calendar: calendarReducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware({ serializableCheck: false }),
 });
 
 export default store;

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -6,6 +6,11 @@ export const theme = createTheme(
   {
     palette: {
       primary: { main: '#3ec192' },
+      eatout: '#FF7583',
+      trip: '#45BFFF',
+      cook: '#FFBC54',
+      clean: '#3EC192',
+      etc: '#727DF0',
     },
   },
   koKR,

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -5,8 +5,7 @@ import { koKR } from '@mui/material/locale';
 export const theme = createTheme(
   {
     palette: {
-      // FIXME: 추후 메인 색상으로 수정
-      primary: { main: '#77b256' },
+      primary: { main: '#3ec192' },
     },
   },
   koKR,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1867,6 +1867,20 @@
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
 
+"@tanstack/query-core@^4.0.0-beta.1":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.1.3.tgz#06b24315577971376b5a15124fc132c0b3ebc1b3"
+  integrity sha512-mSWGovlZnEiVwC99t+Q9uLwGdV9hnq+Z2+sHNAr8tsujzMPRLFNSmWAh/AayAaxIRWPwF4Ce9dmhV2BrYmuK1A==
+
+"@tanstack/react-query@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.1.3.tgz#ebe5b668e321ba63a21ef369b5d263e2466c0e14"
+  integrity sha512-BHI/dV3LOuVOZAaifM6u680Wi5rmiHu4aD3WkvrQT/9fYhHDhTzMdJO8l2Xh0UR7JhM8e9O3f89SJhD3T8Ejgw==
+  dependencies:
+    "@tanstack/query-core" "^4.0.0-beta.1"
+    "@types/use-sync-external-store" "^0.0.3"
+    use-sync-external-store "^1.2.0"
+
 "@testing-library/dom@^8.5.0":
   version "8.16.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.16.1.tgz#96e528c9752d60061128f043e2b43566c0aba2d9"
@@ -8817,7 +8831,7 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-use-sync-external-store@^1.0.0:
+use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
resolves #22 
- 이전 달, 다음 달 이동 기능 추가
- 월별 일정 조회 기능 구현
- 시안대로 메인 페이지 UI 작업 (가족 위젯, 카테고리 별 일정 개수 요약)
- 메인/카테고리별 색상 theme에 추가
- calendarSlice, store 업데이트

![image](https://user-images.githubusercontent.com/84499458/184762975-5b379f60-16f4-45df-9fdb-a5009e89f871.png)

아래 사항들을 보완해야 합니다.
- 카테고리 데이터 영어로 수정 된 후 일정 리스트에 색상 반영
- 위젯 컴포넌트 추후 ranking api로 수정 후 기능 구현, 링크 추가
- 요약 컴포넌트 기능 구현
