### PR TITLE
커뮤니티 게시글 좋아요 및 댓글 수정 삭제 기능 구현

### DIFF
--- a/src/components/calendar/MoreVert.jsx
+++ b/src/components/calendar/MoreVert.jsx
@@ -38,8 +38,6 @@ const MoreVert = ({ schedule }) => {
     },
   });
 
-  // TODO: 삭제 confirm 추가하기
-
   const onClickEdit = () => {
     console.log(schedule.scheduleId);
     navigate('/schedules/edit', { state: schedule });
@@ -70,7 +68,13 @@ const MoreVert = ({ schedule }) => {
           <MdModeEdit />
           수정
         </MenuItem>
-        <MenuItem onClick={deleteData} disableRipple>
+        <MenuItem
+          onClick={() => {
+            const res = confirm('일정을 삭제하시겠습니까?');
+            if (res) deleteData();
+          }}
+          disableRipple
+        >
           <MdDelete />
           삭제
         </MenuItem>

--- a/src/components/community/CommentEditor.jsx
+++ b/src/components/community/CommentEditor.jsx
@@ -12,6 +12,7 @@ const CommentEditor = ({ postId }) => {
     {
       onSuccess: () => {
         alert('댓글이 등록되었습니다!');
+        commentInput.current.value = '';
         return queryClient.invalidateQueries(['communityPost', postId]);
       },
       onError: (err) => console.log(err),

--- a/src/components/community/CommentItem.jsx
+++ b/src/components/community/CommentItem.jsx
@@ -6,7 +6,7 @@ import { Grade } from './LongCard';
 import { hwamokGrades } from '../../utils/data';
 import MoreComment from './MoreComment';
 
-const CommentItem = ({ comment }) => {
+const CommentItem = ({ comment, postId }) => {
   return (
     <Item>
       <Grade>
@@ -18,11 +18,11 @@ const CommentItem = ({ comment }) => {
       <CommentContent>
         <div className="comment-header">
           <strong>{comment.commenter.nickname}</strong>
-          {comment.isCommenter && <MoreComment />}
+          {comment.iamCommenter && (
+            <MoreComment postId={postId} commentId={comment.commentId} />
+          )}
         </div>
-        <p>
-          {comment.content}
-        </p>
+        <p>{comment.content}</p>
         <small>{dayjs(comment.createdAt).format('YYYY년 M월 D일')}</small>
       </CommentContent>
     </Item>

--- a/src/components/community/CommentItem.jsx
+++ b/src/components/community/CommentItem.jsx
@@ -1,12 +1,35 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Grade } from './LongCard';
-import { hwamokGrades } from '../../utils/data';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../../api/AxiosManager';
+
 import MoreComment from './MoreComment';
+import { hwamokGrades } from '../../utils/data';
+import { Grade } from './LongCard';
 
 const CommentItem = ({ comment, postId }) => {
+  const queryClient = useQueryClient();
+  const [onEdit, setOnEdit] = useState(false);
+  const commentRef = useRef();
+
+  useEffect(() => {
+    if (onEdit) commentRef.current.focus();
+  }, [onEdit]);
+
+  const { mutate: editComComment } = useMutation(
+    (data) => api.put(`/posts/${postId}/comments/${comment.commentId}`, data),
+    {
+      onSuccess: () => {
+        alert('댓글을 성공적으로 수정했습니다.');
+        setOnEdit(false);
+        return queryClient.invalidateQueries(['communityPost']);
+      },
+      onError: (err) => console.log(err),
+    },
+  );
+
   return (
     <Item>
       <Grade>
@@ -18,11 +41,46 @@ const CommentItem = ({ comment, postId }) => {
       <CommentContent>
         <div className="comment-header">
           <strong>{comment.commenter.nickname}</strong>
-          {comment.iamCommenter && (
-            <MoreComment postId={postId} commentId={comment.commentId} />
-          )}
+          {comment.iamCommenter &&
+            (onEdit ? (
+              <div>
+                <button
+                  onClick={() =>
+                    editComComment({
+                      content: commentRef.current.value,
+                    })
+                  }
+                  className="btn-comment-edit"
+                >
+                  수정
+                </button>
+                <button onClick={() => setOnEdit(false)}>취소</button>
+              </div>
+            ) : (
+              <MoreComment
+                postId={postId}
+                commentId={comment.commentId}
+                setOnEdit={setOnEdit}
+              />
+            ))}
         </div>
-        <p>{comment.content}</p>
+        {onEdit ? (
+          <input
+            type="text"
+            defaultValue={comment.content}
+            ref={commentRef}
+            style={{
+              width: '100%',
+              padding: '7px',
+              borderRadius: '5px',
+              fontSize: '14px',
+              background: '#f2f2f2',
+            }}
+          />
+        ) : (
+          <p>{comment.content}</p>
+        )}
+
         <small>{dayjs(comment.createdAt).format('YYYY년 M월 D일')}</small>
       </CommentContent>
     </Item>
@@ -35,7 +93,7 @@ CommentItem.propTypes = {
 
 export default CommentItem;
 
-const Item = styled.div`
+const Item = styled.li`
   display: flex;
   padding: 0 27px 30px 20px;
 `;
@@ -58,6 +116,10 @@ const CommentContent = styled.div`
     .MuiIconButton-root {
       padding: 16px 8px;
       margin-top: -15px;
+    }
+    button.btn-comment-edit {
+      color: ${({ theme }) => theme.palette.primary.main};
+      font-weight: 600;
     }
   }
   p {

--- a/src/components/community/LongCard.jsx
+++ b/src/components/community/LongCard.jsx
@@ -74,14 +74,13 @@ const LongCard = ({ post, postId }) => {
           </Tags>
 
           <Counts>
-            {/* TODO: 좋아요 여부(like) 받아와서 색깔 적용 */}
             {post.like ? (
-              <small onClick={deleteLike}>
+              <small onClick={deleteLike} className="btn-like">
                 <IconIsLiked />
                 좋아요 {post.likeCount}
               </small>
             ) : (
-              <small onClick={addLike}>
+              <small onClick={addLike} className="btn-like">
                 <IconLikeCount />
                 좋아요 {post.likeCount}
               </small>
@@ -208,7 +207,9 @@ export const Counts = styled.div`
     align-items: center;
     margin-right: 9px;
     font-size: 12px;
-    cursor: pointer;
+    &.btn-like {
+      cursor: pointer;
+    }
     svg {
       margin-right: 5px;
     }

--- a/src/components/community/LongCard.jsx
+++ b/src/components/community/LongCard.jsx
@@ -2,18 +2,45 @@ import React from 'react';
 import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { IconLikeCount, IconCommentCount } from '../../assets/icons';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../../api/AxiosManager';
+
 import { hwamokGrades } from '../../utils/data';
 import MorePost from './MorePost';
+import {
+  IconIsLiked,
+  IconLikeCount,
+  IconCommentCount,
+} from '../../assets/icons';
 
 const LongCard = ({ post, postId }) => {
+  const queryClient = useQueryClient();
+  const { mutate: addLike } = useMutation(
+    () => api.put(`/posts/${postId}/likes`, { like: true }),
+    {
+      onSuccess: () => {
+        return queryClient.invalidateQueries(['communityPost', postId]);
+      },
+      onError: (err) => console.log(err),
+    },
+  );
+
+  const { mutate: deleteLike } = useMutation(
+    () => api.delete(`/posts/${postId}/likes`),
+    {
+      onSuccess: () => {
+        return queryClient.invalidateQueries(['communityPost', postId]);
+      },
+      onError: (err) => console.log(err),
+    },
+  );
+
   return (
     <>
       <CardContainer>
         <CardTitle>
-          {/* TODO: api에 카테고리 값 추가로 받아오기 */}
           <div>
-            {/* <em>{post.category}</em> */}
+            <em>카테고리 | {post.category}</em>
             <h2>{post.title}</h2>
           </div>
           <MorePost postId={postId} />
@@ -48,10 +75,18 @@ const LongCard = ({ post, postId }) => {
 
           <Counts>
             {/* TODO: 좋아요 여부(like) 받아와서 색깔 적용 */}
-            <small>
-              <IconLikeCount />
-              좋아요 {post.likeCount}
-            </small>
+            {post.like ? (
+              <small onClick={deleteLike}>
+                <IconIsLiked />
+                좋아요 {post.likeCount}
+              </small>
+            ) : (
+              <small onClick={addLike}>
+                <IconLikeCount />
+                좋아요 {post.likeCount}
+              </small>
+            )}
+
             <small>
               <IconCommentCount />
               댓글 {post.comments.length}
@@ -93,12 +128,12 @@ const CardTitle = styled.div`
   }
 
   svg circle {
-      fill: #bababa;
-    }
-    .MuiIconButton-root {
-      height: 34px;
-      margin-top: -17px;
-    }
+    fill: #bababa;
+  }
+  .MuiIconButton-root {
+    height: 34px;
+    margin-top: -17px;
+  }
 `;
 
 export const Profile = styled.div`
@@ -173,6 +208,7 @@ export const Counts = styled.div`
     align-items: center;
     margin-right: 9px;
     font-size: 12px;
+    cursor: pointer;
     svg {
       margin-right: 5px;
     }

--- a/src/components/community/MoreComment.jsx
+++ b/src/components/community/MoreComment.jsx
@@ -7,7 +7,7 @@ import { styled, alpha } from '@mui/material/styles';
 import { MdModeEdit, MdDelete } from 'react-icons/md';
 import { IconMoreHoriz } from '../../assets/icons';
 
-const MoreComment = ({ postId, commentId }) => {
+const MoreComment = ({ postId, commentId, setOnEdit }) => {
   const queryClient = useQueryClient();
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
@@ -20,12 +20,17 @@ const MoreComment = ({ postId, commentId }) => {
     setAnchorEl(null);
   };
 
+  const onClickEdit = () => {
+    setOnEdit(true);
+    handleClose();
+  };
+
   const { mutate: deleteComComment } = useMutation(
     () => api.delete(`/posts/${postId}/comments/${commentId}`),
     {
       onSuccess: () => {
         alert('댓글을 성공적으로 삭제했습니다.');
-        return queryClient.invalidateQueries(['communityPost', postId]);
+        return queryClient.invalidateQueries(['communityPost']);
       },
       onError: (err) => console.log(err),
     },
@@ -52,7 +57,7 @@ const MoreComment = ({ postId, commentId }) => {
         open={open}
         onClose={handleClose}
       >
-        <MenuItem disableRipple>
+        <MenuItem onClick={onClickEdit} disableRipple>
           <MdModeEdit />
           댓글수정
         </MenuItem>

--- a/src/components/community/MoreComment.jsx
+++ b/src/components/community/MoreComment.jsx
@@ -1,10 +1,14 @@
 import React, { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import api from '../../api/AxiosManager';
+
 import { Menu, MenuItem, IconButton } from '@mui/material';
 import { styled, alpha } from '@mui/material/styles';
 import { MdModeEdit, MdDelete } from 'react-icons/md';
 import { IconMoreHoriz } from '../../assets/icons';
 
-const MoreComment = () => {
+const MoreComment = ({ postId, commentId }) => {
+  const queryClient = useQueryClient();
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
 
@@ -15,6 +19,17 @@ const MoreComment = () => {
   const handleClose = () => {
     setAnchorEl(null);
   };
+
+  const { mutate: deleteComComment } = useMutation(
+    () => api.delete(`/posts/${postId}/comments/${commentId}`),
+    {
+      onSuccess: () => {
+        alert('댓글을 성공적으로 삭제했습니다.');
+        return queryClient.invalidateQueries(['communityPost', postId]);
+      },
+      onError: (err) => console.log(err),
+    },
+  );
 
   return (
     <>
@@ -41,7 +56,13 @@ const MoreComment = () => {
           <MdModeEdit />
           댓글수정
         </MenuItem>
-        <MenuItem disableRipple>
+        <MenuItem
+          onClick={() => {
+            const res = confirm('댓글을 삭제하시겠습니까?');
+            if (res) deleteComComment();
+          }}
+          disableRipple
+        >
           <MdDelete />
           댓글삭제
         </MenuItem>

--- a/src/components/community/ShortCard.jsx
+++ b/src/components/community/ShortCard.jsx
@@ -4,7 +4,11 @@ import dayjs from 'dayjs';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { IconLikeCount, IconCommentCount } from '../../assets/icons';
+import {
+  IconIsLiked,
+  IconLikeCount,
+  IconCommentCount,
+} from '../../assets/icons';
 import { Grade, Profile, Info, CardContent, Tags, Counts } from './LongCard';
 import { hwamokGrades } from '../../utils/data';
 
@@ -49,7 +53,7 @@ const ShortCard = ({ post }) => {
             <Counts>
               {/* TODO: 좋아요 여부(like) 받아와서 색깔 적용 */}
               <small>
-                <IconLikeCount />
+                {post.like ? <IconIsLiked /> : <IconLikeCount />}
                 {post.likeCount}
               </small>
               <small>

--- a/src/components/family/Widget.jsx
+++ b/src/components/family/Widget.jsx
@@ -20,7 +20,6 @@ const Widget = () => {
             <img src={hwamokGrades[0].icon} alt={hwamokGrades[0].name} />
           </Circle>
           <div>
-            {/* TODO: 가족 정보 페이지 링크 추가 */}
             <strong>
               {familyInfo.familyName}
               <IconDetail />

--- a/src/components/gallery/AlbumItem.jsx
+++ b/src/components/gallery/AlbumItem.jsx
@@ -170,6 +170,7 @@ const ImgContainer = styled.div`
   cursor: pointer;
   img {
     width: 100%;
+    min-height: 100%;
     display: block;
     aspect-ratio: 3 / 4;
     object-fit: cover;

--- a/src/components/gallery/CommentItem.jsx
+++ b/src/components/gallery/CommentItem.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';

--- a/src/components/gallery/CommentMoreVert.jsx
+++ b/src/components/gallery/CommentMoreVert.jsx
@@ -40,8 +40,6 @@ const CommentMoreVert = ({ commentId, setOnEdit }) => {
     },
   });
 
-  // TODO: 삭제 confirm 추가하기
-
   const onClickEdit = () => {
     setOnEdit(true);
     handleClose();
@@ -71,7 +69,13 @@ const CommentMoreVert = ({ commentId, setOnEdit }) => {
           <MdModeEdit />
           댓글수정
         </MenuItem>
-        <MenuItem onClick={deleteCommentM} disableRipple>
+        <MenuItem
+          onClick={() => {
+            const res = confirm('댓글을 삭제하시겠습니까?');
+            if (res) deleteCommentM();
+          }}
+          disableRipple
+        >
           <MdDelete />
           댓글삭제
         </MenuItem>

--- a/src/components/gallery/ImageModal.jsx
+++ b/src/components/gallery/ImageModal.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import dayjs from 'dayjs';
-import { IconSave } from '../../assets/icons';
-import { IoMdCloseCircle } from 'react-icons/io';
+import { IconClose, IconSave } from '../../assets/icons';
 
 const ImageModal = ({ isVisible, setIsVisible, url, date }) => {
   const ModalClose = () => {
@@ -19,7 +18,7 @@ const ImageModal = ({ isVisible, setIsVisible, url, date }) => {
     <ModalWrap visible={isVisible}>
       <Overlay onClick={onDimmerClick}>
         <button onClick={ModalClose} className="close">
-          <IoMdCloseCircle />
+          <IconClose />
         </button>
         <p>{dayjs(date).format('YYYY년 M월 D일')}</p>
         <a rel="noreferrer" href={url} className="save">
@@ -56,20 +55,19 @@ const Overlay = styled.div`
   z-index: 999;
   button.close {
     position: absolute;
-    top: 10px;
+    top: 11px;
     left: 10px;
     width: 35px;
     height: 35px;
     cursor: pointer;
     z-index: 10;
-    svg {
-      color: #fff;
-      width: 24px;
+    svg path {
+      stroke: #fff;
     }
   }
   a.save {
     position: absolute;
-    top: 15px;
+    top: 17px;
     right: 10px;
     width: 35px;
     height: 35px;

--- a/src/components/gallery/MoreHoriz.jsx
+++ b/src/components/gallery/MoreHoriz.jsx
@@ -40,8 +40,6 @@ const MoreHoriz = ({ album }) => {
     },
   });
 
-  // TODO: 삭제 confirm 추가하기
-
   const onClickEdit = () => {
     console.log(album.id);
     navigate(`/galleries/posts/${scheduleId}/${album.id}/edit`, {
@@ -74,7 +72,13 @@ const MoreHoriz = ({ album }) => {
           <MdModeEdit />
           앨범수정
         </MenuItem>
-        <MenuItem onClick={deleteAlbumM} disableRipple>
+        <MenuItem
+          onClick={() => {
+            const res = confirm('앨범을 삭제하시겠습니까?');
+            if (res) deleteAlbumM();
+          }}
+          disableRipple
+        >
           <MdDelete />
           앨범삭제
         </MenuItem>

--- a/src/pages/community/detail/index.jsx
+++ b/src/pages/community/detail/index.jsx
@@ -40,10 +40,8 @@ const PostDetail = () => {
             댓글 <span>{postData.comments.length}</span>
           </h3>
           {postData.comments.length > 0 ? (
-            postData.comments.map((comment, i) => (
-              // FIXME: API 수정 후 되돌리기
-              // <CommentItem key={comment.commentId} comment={comment} />
-              <CommentItem key={i} comment={comment} />
+            postData.comments.map((comment) => (
+              <CommentItem key={comment.commentId} comment={comment} />
             ))
           ) : (
             <NoComments>

--- a/src/pages/community/detail/index.jsx
+++ b/src/pages/community/detail/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import api from '../../../api/AxiosManager';
@@ -40,9 +40,11 @@ const PostDetail = () => {
             댓글 <span>{postData.comments.length}</span>
           </h3>
           {postData.comments.length > 0 ? (
-            postData.comments.map((comment) => (
-              <CommentItem key={comment.commentId} comment={comment} />
-            ))
+            <ul>
+              {postData.comments.map((comment) => (
+                <CommentItem key={comment.commentId} comment={comment} />
+              ))}
+            </ul>
           ) : (
             <NoComments>
               <div>

--- a/src/pages/gallery/Album.jsx
+++ b/src/pages/gallery/Album.jsx
@@ -163,7 +163,12 @@ const Album = () => {
           <IconSave />
         </button>
         <strong>선택 {size}</strong>
-        <button onClick={deleteImages}>
+        <button
+          onClick={() => {
+            const res = confirm('선택한 이미지를 삭제하시겠습니까?');
+            if (res) deleteImages();
+          }}
+        >
           <FiTrash2 />
         </button>
       </SelectFooter>


### PR DESCRIPTION
#73 
- [게시글 좋아요 추가 삭제 기능 구현](https://github.com/hwamony/harmony_FE/commit/b04a97503fe0e4a0ea52825859f84fae79a3eeec)
- [댓글 수정 기능 구현](https://github.com/hwamony/harmony_FE/commit/86122b7d9493227ad17c5df9bdd66bfdf70018ab)
- [댓글 삭제 기능 구현](https://github.com/hwamony/harmony_FE/commit/c84cfafc8aae5ce8779326cb1dafdf6d5d3dd0bf)
- 캘린더, 갤러리, 커뮤니티 페이지에서 삭제하는 경우 확인창 띄우도록 수정
- 갤러리 개별 이미지 모달 닫기 버튼 수정(모바일에서 작게 보이는 문제 해결), 앨범 그리드 스타일 수정 